### PR TITLE
feat: adds support for sorted query results

### DIFF
--- a/packages/tinybased/src/fixture/database.ts
+++ b/packages/tinybased/src/fixture/database.ts
@@ -16,11 +16,11 @@ const noteSchema = {
 type UserRow = ParseTableSchema<typeof userSchema>;
 type NoteRow = ParseTableSchema<typeof noteSchema>;
 
-const USER_ID_1 = 'user1';
-const USER_ID_2 = 'user2';
-const NOTE_ID = 'noteId1';
-const NOTE_ID_2 = 'noteId2';
-const NOTE_ID_3 = 'noteId3';
+export const USER_ID_1 = 'user1';
+export const USER_ID_2 = 'user2';
+export const NOTE_ID = 'noteId1';
+export const NOTE_ID_2 = 'noteId2';
+export const NOTE_ID_3 = 'noteId3';
 
 const user1: UserRow = {
   id: USER_ID_1,
@@ -32,6 +32,7 @@ const user1: UserRow = {
 const user2: UserRow = {
   ...user1,
   id: USER_ID_2,
+  age: 44,
   name: 'Bob',
 };
 

--- a/packages/tinybased/src/lib/queries/SimpleQuery.ts
+++ b/packages/tinybased/src/lib/queries/SimpleQuery.ts
@@ -1,5 +1,5 @@
 import { Queries } from 'tinybase/queries';
-import { Table } from '../types';
+import { QueryOptions, Table } from '../types';
 
 export class SimpleQuery<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -13,6 +13,17 @@ export class SimpleQuery<
 
   public getResultRowIds() {
     return this.queries.getResultRowIds(this.queryId);
+  }
+
+  public getSortedRowIds(sortBy: TCells, options?: QueryOptions) {
+    const { descending = false, offset, limit } = options || {};
+    return this.queries.getResultSortedRowIds(
+      this.queryId,
+      sortBy as string,
+      descending,
+      offset,
+      limit
+    );
   }
 
   public getResultTable(): Record<string, Pick<TTable, TCells>> {

--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -4,10 +4,11 @@ import {
   useResultRowIds,
   useRow as tbUseRow,
   useCell as tbUseCell,
+  useResultSortedRowIds,
 } from 'tinybase/ui-react';
 import { SimpleQuery } from './queries';
 import { TinyBased } from './tinybased';
-import { Table, TinyBaseSchema } from './types';
+import { QueryOptions, Table, TinyBaseSchema } from './types';
 
 export const useSimpleQueryResultTable = <
   TTable extends Table = {},
@@ -23,6 +24,21 @@ export const useSimpleQueryResultTable = <
 
 export function useSimpleQueryResultIds(query: SimpleQuery) {
   return useResultRowIds(query.queryId, query.queries);
+}
+
+export function useSimpleQuerySortedResultIds<
+  TTable extends Table = {},
+  TCells extends keyof TTable = never
+>(query: SimpleQuery<TTable, TCells>, sortBy: TCells, options?: QueryOptions) {
+  const { descending = false, offset, limit } = options || {};
+  return useResultSortedRowIds(
+    query.queryId,
+    sortBy as string,
+    descending,
+    offset,
+    limit,
+    query.queries
+  );
 }
 
 export type TinyBasedReactHooks<TBSchema extends TinyBaseSchema = {}> = {

--- a/packages/tinybased/src/lib/tinybased.ts
+++ b/packages/tinybased/src/lib/tinybased.ts
@@ -144,6 +144,13 @@ export class TinyBased<
     return this.store.setCell(table as string, rowId, cellId as string, value);
   }
 
+  deleteCell<
+    TTable extends keyof TBSchema,
+    TCell extends keyof TBSchema[TTable]
+  >(table: TTable, rowId: string, cellId: TCell) {
+    return this.store.delCell(table as string, rowId, cellId as string);
+  }
+
   getLocalIds(relationshipName: TRelationships, rowId: string) {
     return this.relationships.getLocalRowIds(relationshipName, rowId);
   }

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -7,6 +7,13 @@ export type SchemaHydrators<TBSchema extends TinyBaseSchema> = {
 };
 
 export type Aggregations = 'avg' | 'count' | 'sum' | 'max' | 'min';
+
+export type QueryOptions = {
+  descending?: boolean;
+  offset?: number;
+  limit?: number;
+};
+
 export type RelationshipDefinition = {
   name: string;
   from: string;


### PR DESCRIPTION
- Adds ability to sort a SimpleQuery based on its selected fields.
- Works for queries that are manually invoked as well as reactively with hooks
- Implements `deleteCell`