### PR TITLE
feat: new table builder API

### DIFF
--- a/packages/tinybased/src/fixture/database.ts
+++ b/packages/tinybased/src/fixture/database.ts
@@ -1,20 +1,18 @@
-import { ParseTableSchema, SchemaBuilder } from '../';
+import { InferTable, SchemaBuilder, TableBuilder } from '../';
 
-const userSchema = {
-  id: String,
-  name: String,
-  age: Number,
-  isAdmin: Boolean,
-};
+export const usersTable = new TableBuilder('users')
+  .add('id', 'string')
+  .add('name', 'string')
+  .add('age', 'number')
+  .add('isAdmin', 'boolean');
 
-const noteSchema = {
-  id: String,
-  text: String,
-  userId: String,
-};
+export const notesTable = new TableBuilder('notes')
+  .add('id', 'string')
+  .add('userId', 'string')
+  .addOptional('text', 'string');
 
-type UserRow = ParseTableSchema<typeof userSchema>;
-type NoteRow = ParseTableSchema<typeof noteSchema>;
+type UserRow = InferTable<typeof usersTable>;
+type NoteRow = InferTable<typeof notesTable>;
 
 export const USER_ID_1 = 'user1';
 export const USER_ID_2 = 'user2';
@@ -61,8 +59,8 @@ export type Schema = {
 
 export async function makeTinyBasedTestFixture() {
   const tinyBasedSample = await new SchemaBuilder()
-    .defineTable('users', userSchema)
-    .defineTable('notes', noteSchema)
+    .addTable(usersTable)
+    .addTable(notesTable)
     .defineHydrators({
       users: () => Promise.resolve([user1, user2]),
       notes: () => Promise.resolve([note1, note2, note3]),

--- a/packages/tinybased/src/index.ts
+++ b/packages/tinybased/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/tinybased-react';
 export * from './lib/types';
 export * from './lib/SchemaBuilder';
 export * from './lib/queries';
+export * from './lib//TableBuilder';

--- a/packages/tinybased/src/index.ts
+++ b/packages/tinybased/src/index.ts
@@ -3,4 +3,4 @@ export * from './lib/tinybased-react';
 export * from './lib/types';
 export * from './lib/SchemaBuilder';
 export * from './lib/queries';
-export * from './lib//TableBuilder';
+export * from './lib/TableBuilder';

--- a/packages/tinybased/src/lib/TableBuilder.ts
+++ b/packages/tinybased/src/lib/TableBuilder.ts
@@ -1,0 +1,58 @@
+import { OnlyStringKeys, Prettify } from './types';
+
+interface CellTypeMap {
+  string: string;
+  number: number;
+  boolean: boolean;
+}
+
+type CellStringType = 'string' | 'boolean' | 'number';
+
+export class TableBuilder<
+  TName extends string = never,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  TCells extends Record<string, unknown> = {}
+> {
+  private readonly _cells: Array<{ name: string; type: CellStringType }> = [];
+
+  // TODO: It would be awesome if we could default to 'id' only if it exists as a non optional string on the
+  // current table builder. If not present, it should not be possible to add the Table to the SchemaBuilder
+  private _keys: string[] = ['id'];
+
+  constructor(public readonly tableName: TName) {}
+
+  public get keys() {
+    return this._keys;
+  }
+
+  add<TCellName extends string, TCellType extends CellStringType>(
+    name: TCellName,
+    type: TCellType
+  ): TableBuilder<TName, TCells & Record<TCellName, CellTypeMap[TCellType]>> {
+    this._cells.push({ name, type });
+    return this;
+  }
+
+  addOptional<TCellName extends string, TCellType extends CellStringType>(
+    name: TCellName,
+    type: TCellType
+  ): TableBuilder<
+    TName,
+    TCells & Partial<Record<TCellName, CellTypeMap[TCellType]>>
+  > {
+    this._cells.push({ name, type });
+
+    return this;
+  }
+
+  keyBy<TCellName extends OnlyStringKeys<TCells>>(
+    cells: TCellName | TCellName[]
+  ) {
+    this._keys = Array.isArray(cells) ? cells : [cells];
+    return this;
+  }
+}
+
+export type InferTable<T> = T extends TableBuilder<infer TName, infer TCells>
+  ? Prettify<TCells>
+  : never;

--- a/packages/tinybased/src/lib/queries/SimpleQuery.ts
+++ b/packages/tinybased/src/lib/queries/SimpleQuery.ts
@@ -1,10 +1,10 @@
 import { Queries } from 'tinybase/cjs/queries';
-import { QueryOptions, Table } from '../types';
+import { OnlyStringKeys, QueryOptions, Table } from '../types';
 
 export class SimpleQuery<
   // eslint-disable-next-line @typescript-eslint/ban-types
   TTable extends Table = {},
-  TCells extends keyof TTable = never
+  TCells extends OnlyStringKeys<TTable> = never
 > {
   constructor(
     public readonly queries: Queries,
@@ -19,7 +19,7 @@ export class SimpleQuery<
     const { descending = false, offset, limit } = options || {};
     return this.queries.getResultSortedRowIds(
       this.queryId,
-      sortBy as string,
+      sortBy,
       descending,
       offset,
       limit

--- a/packages/tinybased/src/lib/queries/SimpleQueryBuilder.ts
+++ b/packages/tinybased/src/lib/queries/SimpleQueryBuilder.ts
@@ -1,12 +1,12 @@
 import { Queries } from 'tinybase/cjs/queries';
-import { Aggregations, Cell, Table } from '../types';
+import { Aggregations, Cell, OnlyStringKeys, Table } from '../types';
 import { SimpleAggregateQuery } from './SimpleAggregateQuery';
 import { SimpleQuery } from './SimpleQuery';
 
 export class SimpleQueryBuilder<
   // eslint-disable-next-line @typescript-eslint/ban-types
   TTable extends Table = {},
-  TCells extends keyof TTable = never
+  TCells extends OnlyStringKeys<TTable> = never
 > {
   // TODO maybe we should model this as a Map/Record so that conditions for a given cell
   // can be overwritten. This would allow for easier composition of query builder instances
@@ -18,7 +18,7 @@ export class SimpleQueryBuilder<
     private readonly queries: Queries
   ) {}
 
-  select<TCell extends keyof TTable>(
+  select<TCell extends OnlyStringKeys<TTable>>(
     cell: TCell
   ): SimpleQueryBuilder<TTable, TCells | TCell> {
     this.selects.push(cell as any);

--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -8,11 +8,11 @@ import {
 } from 'tinybase/cjs/ui-react';
 import { SimpleQuery } from './queries';
 import { TinyBased } from './tinybased';
-import { QueryOptions, Table, TinyBaseSchema } from './types';
+import { OnlyStringKeys, QueryOptions, Table, TinyBaseSchema } from './types';
 
 export const useSimpleQueryResultTable = <
   TTable extends Table = {},
-  TCells extends keyof TTable = never
+  TCells extends OnlyStringKeys<TTable> = never
 >(
   query: SimpleQuery<TTable, TCells>
 ): Record<string, Pick<TTable, TCells>> => {
@@ -28,12 +28,12 @@ export function useSimpleQueryResultIds(query: SimpleQuery) {
 
 export function useSimpleQuerySortedResultIds<
   TTable extends Table = {},
-  TCells extends keyof TTable = never
+  TCells extends OnlyStringKeys<TTable> = never
 >(query: SimpleQuery<TTable, TCells>, sortBy: TCells, options?: QueryOptions) {
   const { descending = false, offset, limit } = options || {};
   return useResultSortedRowIds(
     query.queryId,
-    sortBy as string,
+    sortBy,
     descending,
     offset,
     limit,

--- a/packages/tinybased/src/lib/types.spec.ts
+++ b/packages/tinybased/src/lib/types.spec.ts
@@ -1,32 +1,17 @@
+import { usersTable } from '../fixture/database';
 import { SchemaBuilder } from './SchemaBuilder';
-import { ParseTableSchema } from './types';
 
-const ExampleSchema = {
-  id: String,
-  name: String,
-  age: Number,
-  isAdmin: Boolean,
-};
-
-type ExpectedSchemaType = {
+type ExpectedUserType = {
   id: string;
   name: string;
   age: number;
   isAdmin: boolean;
 };
 
-it('should parse table schema from type utils', async () => {
-  const record = {} as ParseTableSchema<typeof ExampleSchema>;
-
-  expectTypeOf(record).toMatchTypeOf<ExpectedSchemaType>();
-});
-
 it('should parse table schema from builder', async () => {
-  const baseBuilder = await new SchemaBuilder()
-    .defineTable('example', ExampleSchema)
-    .build();
+  const baseBuilder = await new SchemaBuilder().addTable(usersTable).build();
 
-  const record = baseBuilder.getRow('example', '1');
+  const record = baseBuilder.getRow('users', '1');
 
-  expectTypeOf(record).toMatchTypeOf<ExpectedSchemaType>();
+  expectTypeOf(record).toMatchTypeOf<ExpectedUserType>();
 });

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -27,37 +27,12 @@ export type RowChangeHandler<TBSchema extends TinyBaseSchema> = (
   entity?: Table
 ) => Promise<void>;
 
-type SchemaCellType =
-  | StringConstructor
-  | NumberConstructor
-  | BooleanConstructor
-  | null
-  | undefined;
+export type OnlyStringKeys<T extends Record<PropertyKey, unknown>> = Exclude<
+  keyof T,
+  number | symbol
+>;
 
-export type TableSchema = Record<string, SchemaCellType>;
-
-type ParseSchemaCellType<T extends SchemaCellType> = T extends StringConstructor
-  ? string
-  : T extends NumberConstructor
-  ? number
-  : T extends BooleanConstructor
-  ? boolean
-  : T extends null
-  ? null
-  : T extends undefined
-  ? undefined
-  : never;
-
-export type ParseTableSchema<TSchema extends TableSchema> =
-  UndefinedToOptional<{
-    [K in keyof TSchema]: ParseSchemaCellType<TSchema[K]>;
-  }>;
-
-// Utils
-
-type UndefinedProperties<T> = {
-  [P in keyof T]-?: undefined extends T[P] ? P : never;
-}[keyof T];
-
-type UndefinedToOptional<T> = Partial<Pick<T, UndefinedProperties<T>>> &
-  Pick<T, Exclude<keyof T, UndefinedProperties<T>>>;
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};


### PR DESCRIPTION
## Improvements
- Adds a new API for defining Tables using a fluent builder pattern. This allows us to infer types nicely while storing useful runtime metadata about table definitions. It also sets us up to be able to map nicely to the `setSchema` methods that are exposed by TinyBase itself
- Introduces the ability to define composite keys for entities which will be honored during hydration
- Adds the ability to represent potentially undefined cell values in our Table definitions
- Improves some types by making sure that we narrow keys down to only `string` and remove `number | Symbol` which means we don't have to cast to `as string` nearly as often