### PR TITLE
feat: adds APIs for definining persistors (hydrate + save) [CR-2567]

### DIFF
--- a/packages/tinybased/.eslintrc.json
+++ b/packages/tinybased/.eslintrc.json
@@ -14,5 +14,15 @@
       "files": ["*.js", "*.jsx"],
       "rules": {}
     }
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
+  }
 }

--- a/packages/tinybased/src/lib/SchemaBuilder.ts
+++ b/packages/tinybased/src/lib/SchemaBuilder.ts
@@ -2,8 +2,9 @@
 import { TableBuilder } from './TableBuilder';
 import { TinyBased } from './tinybased';
 import {
+  DeepPrettify,
   OnlyStringKeys,
-  PersisterSchema,
+  TableDefs,
   RelationshipDefinition,
   RowChangeHandler,
   SchemaHydrator,
@@ -88,7 +89,7 @@ export class SchemaBuilder<
             keyBy: tableBuilder.keys,
           },
         ])
-      ) as PersisterSchema<TBSchema>;
+      ) as DeepPrettify<TableDefs<TBSchema>>;
 
       await Promise.all(
         Array.from(this.persisters).map((persister) =>
@@ -99,12 +100,12 @@ export class SchemaBuilder<
     // Hydrate tables
 
     Object.entries(this.hydrators).forEach((hydrator) => {
-      tb.tableHydrators.add(hydrator as SchemaHydrator<TBSchema>);
+      tb.hydrators.add(hydrator as SchemaHydrator<TBSchema>);
     });
 
     this.persisters.forEach((persister) => {
       Array.from(this.tables.keys()).forEach((tableName) => {
-        tb.tableHydrators.add([
+        tb.hydrators.add([
           tableName,
           () => persister.getTable(tableName),
         ] as SchemaHydrator<TBSchema>);
@@ -120,10 +121,6 @@ export class SchemaBuilder<
     });
     this.rowRemovedHandlers.forEach((handler) => {
       tb.events.onRowRemoved.add(handler);
-    });
-
-    Object.entries(this.hydrators).forEach((hydrator) => {
-      tb.tableHydrators.add(hydrator as SchemaHydrator<TBSchema>);
     });
 
     this.persisters.forEach((persister) => {

--- a/packages/tinybased/src/lib/TableBuilder.ts
+++ b/packages/tinybased/src/lib/TableBuilder.ts
@@ -8,12 +8,18 @@ interface CellTypeMap {
 
 type CellStringType = 'string' | 'boolean' | 'number';
 
+export type CellSchema = {
+  name: string;
+  type: CellStringType;
+  optional?: boolean;
+};
+
 export class TableBuilder<
   TName extends string = never,
   // eslint-disable-next-line @typescript-eslint/ban-types
   TCells extends Record<string, unknown> = {}
 > {
-  private readonly _cells: Array<{ name: string; type: CellStringType }> = [];
+  private readonly _cells: CellSchema[] = [];
 
   // TODO: It would be awesome if we could default to 'id' only if it exists as a non optional string on the
   // current table builder. If not present, it should not be possible to add the Table to the SchemaBuilder
@@ -23,6 +29,10 @@ export class TableBuilder<
 
   public get keys() {
     return this._keys;
+  }
+
+  public get cells() {
+    return this._cells;
   }
 
   add<TCellName extends string, TCellType extends CellStringType>(
@@ -40,7 +50,7 @@ export class TableBuilder<
     TName,
     TCells & Partial<Record<TCellName, CellTypeMap[TCellType]>>
   > {
-    this._cells.push({ name, type });
+    this._cells.push({ name, type, optional: true });
 
     return this;
   }
@@ -53,6 +63,6 @@ export class TableBuilder<
   }
 }
 
-export type InferTable<T> = T extends TableBuilder<infer TName, infer TCells>
+export type InferTable<T> = T extends TableBuilder<infer _TName, infer TCells>
   ? Prettify<TCells>
   : never;

--- a/packages/tinybased/src/lib/queries/SimpleQuery.ts
+++ b/packages/tinybased/src/lib/queries/SimpleQuery.ts
@@ -1,5 +1,5 @@
 import { Queries } from 'tinybase/cjs/queries';
-import { OnlyStringKeys, QueryOptions, Table } from '../types';
+import { DeepPrettify, OnlyStringKeys, QueryOptions, Table } from '../types';
 
 export class SimpleQuery<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -11,7 +11,7 @@ export class SimpleQuery<
     public readonly queryId: string
   ) {}
 
-  public getResultRowIds() {
+  public getResultRowIds(): string[] {
     return this.queries.getResultRowIds(this.queryId);
   }
 
@@ -26,10 +26,9 @@ export class SimpleQuery<
     );
   }
 
-  public getResultTable(): Record<string, Pick<TTable, TCells>> {
-    return this.queries.getResultTable(this.queryId) as Record<
-      string,
-      Pick<TTable, TCells>
+  public getResultTable(): DeepPrettify<Record<string, Pick<TTable, TCells>>> {
+    return this.queries.getResultTable(this.queryId) as DeepPrettify<
+      Record<string, Pick<TTable, TCells>>
     >;
   }
 }

--- a/packages/tinybased/src/lib/tinybased.spec.ts
+++ b/packages/tinybased/src/lib/tinybased.spec.ts
@@ -1,6 +1,6 @@
 import { SchemaBuilder } from './SchemaBuilder';
 import { notesTable, usersTable } from '../fixture/database';
-import { Table } from './types';
+import { InferSchema, SchemaPersister, Table } from './types';
 import { TableBuilder } from './TableBuilder';
 
 const USER_ID_1 = 'user1';
@@ -349,6 +349,103 @@ describe('tinybased', () => {
       based.deleteRow('users', ID);
       await wait();
       expect(mockStorage.get(ID)).toBeUndefined();
+    });
+  });
+
+  describe('persister', () => {
+    let mockStorage: Record<string, any> = {};
+    const onRowAddedOrUpdated = vi.fn(async (tableName, rowId, entity) => {
+      mockStorage[tableName] = mockStorage[tableName] || [];
+      const existingIndex = mockStorage[tableName].findIndex(
+        (entity: any) => entity.id === rowId
+      );
+      if (existingIndex !== -1) {
+        mockStorage[tableName][existingIndex] = entity;
+      } else {
+        mockStorage[tableName].push(entity);
+      }
+    });
+
+    const TestPersister = (
+      databaseName: string
+    ): SchemaPersister<InferSchema<typeof baseBuilder>> => ({
+      onInit: async () => {
+        mockStorage['__databaseName'] = databaseName;
+      },
+      getTable: async (tableName) => {
+        return mockStorage[tableName] || [];
+      },
+      onRowAddedOrUpdated,
+      onRowRemoved: async (tableName, rowId) => {
+        mockStorage[tableName] = mockStorage[tableName] || [];
+        mockStorage[tableName] = mockStorage[tableName].filter(
+          (entity: any) => entity.id !== rowId
+        );
+      },
+    });
+
+    const basedSchema = new SchemaBuilder()
+      .addTable(usersTable)
+      .addPersister(TestPersister('test_db'));
+
+    beforeEach(() => {
+      mockStorage = {};
+      onRowAddedOrUpdated.mockClear();
+    });
+
+    it('calls onInit on build', async () => {
+      await basedSchema.build();
+      expect(mockStorage['__databaseName']).toBe('test_db');
+    });
+
+    it('hydrates from persister', async () => {
+      mockStorage = {
+        users: [exampleUser],
+      };
+
+      const based = await basedSchema.build();
+
+      expect(based.getRow('users', USER_ID_1)).toEqual(exampleUser);
+    });
+
+    it('persists row add/update', async () => {
+      const based = await basedSchema.build();
+
+      based.setRow('users', USER_ID_1, exampleUser);
+
+      expect(mockStorage['users']).toEqual([exampleUser]);
+
+      based.setCell('users', USER_ID_1, 'age', 85);
+
+      expect(mockStorage['users']).toEqual([{ ...exampleUser, age: 85 }]);
+    });
+
+    it('persists row removal', async () => {
+      mockStorage = {
+        users: [exampleUser],
+      };
+
+      const based = await basedSchema.build();
+
+      based.deleteRow('users', USER_ID_1);
+
+      expect(mockStorage['users']).toEqual([]);
+    });
+
+    it('it should not invoke row change events on hydration', async () => {
+      mockStorage = {
+        users: [exampleUser],
+      };
+
+      const otherEventHandlers = vi.fn();
+
+      const based = await basedSchema
+        .onRowAddedOrUpdated(otherEventHandlers)
+        .build();
+
+      expect(onRowAddedOrUpdated).not.toBeCalled();
+      expect(otherEventHandlers).not.toBeCalled();
+      expect(based.getRow('users', USER_ID_1)).toEqual(exampleUser);
     });
   });
 });

--- a/packages/tinybased/src/lib/tinybased.ts
+++ b/packages/tinybased/src/lib/tinybased.ts
@@ -35,7 +35,7 @@ export class TinyBased<
     onRowAddedOrUpdated: new Set<RowChangeHandler<TBSchema>>(),
     onRowRemoved: new Set<RowChangeHandler<TBSchema>>(),
   } as const;
-  public readonly tableHydrators = new Set<SchemaHydrator<TBSchema>>();
+  public readonly hydrators = new Set<SchemaHydrator<TBSchema>>();
 
   /** It is highly recommended that you do not call this constructor directly unless you know exactly what you're doing.
    * Instead, use the SchemaBuilder class to build your schema and then call .build() to receive an instance of this class
@@ -89,9 +89,9 @@ export class TinyBased<
   }
 
   public async hydrate() {
-    if (this.tableHydrators.size > 0) {
+    if (this.hydrators.size > 0) {
       await Promise.all(
-        Array.from(this.tableHydrators).map(async ([table, hydrator]) => {
+        Array.from(this.hydrators).map(async ([table, hydrator]) => {
           const entries = await hydrator();
           const tableKeys = this.tables.get(table)?.keys ?? [];
           this.store.setTable(

--- a/packages/tinybased/src/lib/tinybased.ts
+++ b/packages/tinybased/src/lib/tinybased.ts
@@ -13,7 +13,7 @@ import { SimpleQueryBuilder } from './queries';
 import {
   RelationshipDefinition,
   RowChangeHandler,
-  SchemaHydrators,
+  SchemaHydrator,
   TinyBaseSchema,
 } from './types';
 import keyBy from 'lodash/keyBy';
@@ -21,11 +21,6 @@ import { TableBuilder } from './TableBuilder';
 
 const makeTableRowCountMetricName = (tableName: string) =>
   `tinybased_internal_row_count_${tableName}`;
-
-export type TinyBasedOptions<TBSchema extends TinyBaseSchema = {}> = {
-  rowAddedOrUpdatedHandler?: RowChangeHandler<TBSchema>;
-  rowRemovedHandler?: RowChangeHandler<TBSchema>;
-};
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export class TinyBased<
@@ -36,15 +31,18 @@ export class TinyBased<
   public readonly metrics: Metrics;
   public readonly relationships: Relationships;
   public readonly queries: Queries;
+  public readonly events = {
+    onRowAddedOrUpdated: new Set<RowChangeHandler<TBSchema>>(),
+    onRowRemoved: new Set<RowChangeHandler<TBSchema>>(),
+  } as const;
+  public readonly tableHydrators = new Set<SchemaHydrator<TBSchema>>();
 
   /** It is highly recommended that you do not call this constructor directly unless you know exactly what you're doing.
    * Instead, use the SchemaBuilder class to build your schema and then call .build() to receive an instance of this class
    */
   constructor(
     private readonly tables: Map<string, TableBuilder<any, any>>,
-    relationshipDefs: RelationshipDefinition[] = [],
-    private readonly hydrators: SchemaHydrators<TBSchema> = {} as SchemaHydrators<TBSchema>,
-    private readonly options: TinyBasedOptions<TBSchema> = {}
+    relationshipDefs: RelationshipDefinition[] = []
   ) {
     this.store = createStore();
     this.metrics = createMetrics(this.store);
@@ -74,31 +72,35 @@ export class TinyBased<
    */
   public init() {
     if (
-      this.options.rowAddedOrUpdatedHandler ||
-      this.options.rowAddedOrUpdatedHandler
+      this.events.onRowAddedOrUpdated.size > 0 ||
+      this.events.onRowRemoved.size > 0
     ) {
       this.store.addRowListener(null, null, (store, table, rowId) => {
         if (store.hasRow(table, rowId)) {
           const row = store.getRow(table, rowId);
-          this.options.rowAddedOrUpdatedHandler?.(table, rowId, row);
+          this.events.onRowAddedOrUpdated?.forEach((handler) =>
+            handler(table, rowId, row)
+          );
         } else {
-          this.options.rowRemovedHandler?.(table, rowId);
+          this.events.onRowRemoved?.forEach((handler) => handler(table, rowId));
         }
       });
     }
   }
 
   public async hydrate() {
-    await Promise.all(
-      Object.entries(this.hydrators).map(async ([table, hydrator]) => {
-        const entries = await hydrator();
-        const tableKeys = this.tables.get(table)?.keys ?? [];
-        this.store.setTable(
-          table,
-          keyBy(entries, (e) => `${tableKeys.map((k) => e[k]).join('::')}`)
-        );
-      })
-    );
+    if (this.tableHydrators.size > 0) {
+      await Promise.all(
+        Array.from(this.tableHydrators).map(async ([table, hydrator]) => {
+          const entries = await hydrator();
+          const tableKeys = this.tables.get(table)?.keys ?? [];
+          this.store.setTable(
+            table,
+            keyBy(entries, (e) => `${tableKeys.map((k) => e[k]).join('::')}`)
+          );
+        })
+      );
+    }
   }
 
   simpleQuery<TTable extends keyof TBSchema>(

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -1,9 +1,32 @@
+import { SchemaBuilder } from './SchemaBuilder';
+
 export type Cell = string | number | boolean;
 export type Table = Record<string, Cell>;
 export type TinyBaseSchema = Record<string, Table>;
+export type TableNames<TBSchema extends TinyBaseSchema> =
+  OnlyStringKeys<TBSchema>;
+
+export type InferSchema<SB> = SB extends SchemaBuilder<infer S, any>
+  ? S
+  : never;
 
 export type SchemaHydrators<TBSchema extends TinyBaseSchema> = {
   [TTableName in keyof TBSchema]: () => Promise<TBSchema[TTableName][]>;
+};
+
+export type SchemaHydrator<TBSchema extends TinyBaseSchema> = {
+  [TTableName in keyof TBSchema]: TTableName extends string
+    ? [TTableName, () => Promise<TBSchema[TTableName][]>]
+    : never;
+}[keyof TBSchema];
+
+export type SchemaPersister<TBSchema extends TinyBaseSchema> = {
+  onInit: () => Promise<void> | void;
+  getTable: <TTableName extends keyof TBSchema>(
+    tableName: TTableName
+  ) => Promise<TBSchema[TTableName][]> | TBSchema[TTableName][];
+  onRowAddedOrUpdated: RowChangeHandler<TBSchema>;
+  onRowRemoved: RowChangeHandler<TBSchema>;
 };
 
 export type Aggregations = 'avg' | 'count' | 'sum' | 'max' | 'min';

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { SchemaBuilder } from './SchemaBuilder';
+import { CellSchema } from './TableBuilder';
 
 export type Cell = string | number | boolean;
 export type Table = Record<string, Cell>;
@@ -20,8 +21,15 @@ export type SchemaHydrator<TBSchema extends TinyBaseSchema> = {
     : never;
 }[keyof TBSchema];
 
+export type PersisterSchema<TBSchema extends TinyBaseSchema> = {
+  [TTableName in keyof TBSchema]: {
+    cells: CellSchema[];
+    keyBy: string[];
+  };
+};
+
 export type SchemaPersister<TBSchema extends TinyBaseSchema> = {
-  onInit: () => Promise<void> | void;
+  onInit: (schema: PersisterSchema<TBSchema>) => Promise<void> | void;
   getTable: <TTableName extends keyof TBSchema>(
     tableName: TTableName
   ) => Promise<TBSchema[TTableName][]> | TBSchema[TTableName][];

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -21,7 +21,7 @@ export type SchemaHydrator<TBSchema extends TinyBaseSchema> = {
     : never;
 }[keyof TBSchema];
 
-export type PersisterSchema<TBSchema extends TinyBaseSchema> = {
+export type TableDefs<TBSchema extends TinyBaseSchema> = {
   [TTableName in keyof TBSchema]: {
     cells: CellSchema[];
     keyBy: string[];
@@ -29,7 +29,7 @@ export type PersisterSchema<TBSchema extends TinyBaseSchema> = {
 };
 
 export type SchemaPersister<TBSchema extends TinyBaseSchema> = {
-  onInit: (schema: PersisterSchema<TBSchema>) => Promise<void> | void;
+  onInit: (schema: DeepPrettify<TableDefs<TBSchema>>) => Promise<void> | void;
   getTable: <TTableName extends keyof TBSchema>(
     tableName: TTableName
   ) => Promise<TBSchema[TTableName][]> | TBSchema[TTableName][];
@@ -67,3 +67,16 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
   // eslint-disable-next-line @typescript-eslint/ban-types
 } & {};
+
+export type DeepPrettify<T> = T extends object
+  ? {
+      [K in keyof T]: T[K] extends object
+        ? DeepPrettify<T[K]>
+        : T[K] extends Array<infer U>
+        ? Array<DeepPrettify<U>>
+        : T[K];
+      // eslint-disable-next-line @typescript-eslint/ban-types
+    } & {}
+  : T extends Array<infer U>
+  ? Array<DeepPrettify<U>>
+  : T;


### PR DESCRIPTION
## Improvements

Defines a new API which makes it easier to attach a Persistor to the SchemaBuilder. The purpose of the persistor is two fold: 
    - A conveient way to ensure that data coming into a TinyBased instance are hydrated from external storage
    - Ensures that all future changes to the TinyBased instance are automaticaly synced back to the external storage

This new API will make it much easier to define pluggable wrappers for syncing two and from things storage like IndexedDB, SQLite, a networked service, etc