### PR TITLE
fix: only allow aggregation on selected cells [CR-2580]

### DIFF
--- a/packages/tinybased/src/lib/queries/SimpleQueryBuilder.ts
+++ b/packages/tinybased/src/lib/queries/SimpleQueryBuilder.ts
@@ -41,8 +41,8 @@ export class SimpleQueryBuilder<
    * @param cell
    * @param aggregateOperation
    */
-  aggregate<TCell extends keyof TTable, TAggregation extends Aggregations>(
-    cell: TCell,
+  aggregate<TAggregation extends Aggregations>(
+    cell: TCells,
     aggregateOperation: TAggregation
   ) {
     const queryId = this.internalBuild({

--- a/packages/tinybased/src/lib/tinybased.spec.ts
+++ b/packages/tinybased/src/lib/tinybased.spec.ts
@@ -29,8 +29,8 @@ describe('tinybased', () => {
 
     const table = based.getTable('users');
     expect(table).toEqual({
-      '1': exampleUser
-    })
+      '1': exampleUser,
+    });
 
     expectTypeOf(table).toEqualTypeOf<
       Record<


### PR DESCRIPTION
## Improvements

Prevents the user from attempting to aggregate on a cell which hadn't been selected as part of the query. Doing so would result in the aggregation always returning undefined