### PR TITLE
feat: Exposes type-safe Relationship hooks and useRowIds hook

### DIFF
--- a/packages/tinybased/src/fixture/database.ts
+++ b/packages/tinybased/src/fixture/database.ts
@@ -65,6 +65,7 @@ export async function makeTinyBasedTestFixture() {
       users: () => Promise.resolve([user1, user2]),
       notes: () => Promise.resolve([note1, note2, note3]),
     })
+    .defineRelationship('userNotes', 'notes', 'users', 'userId')
     .build();
 
   return tinyBasedSample;

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -8,8 +8,22 @@ export type TinyBaseSchema = Record<string, Table>;
 export type TableNames<TBSchema extends TinyBaseSchema> =
   OnlyStringKeys<TBSchema>;
 
-export type InferSchema<SB> = SB extends SchemaBuilder<infer S, any>
+export type InferSchema<T> = T extends SchemaBuilder<infer S, any>
   ? S
+  : T extends TinyBased<infer S, any>
+  ? S
+  : never;
+
+export type InferTableNames<T> = T extends SchemaBuilder<any, any>
+  ? TableNames<InferSchema<T>>
+  : T extends TinyBased<any, any>
+  ? TableNames<InferSchema<T>>
+  : never;
+
+export type InferRelationShip<T> = T extends SchemaBuilder<any, infer R>
+  ? R
+  : T extends TinyBased<any, infer R>
+  ? R
   : never;
 
 export type InferTinyBased<SB> = SB extends SchemaBuilder<infer S, infer R>


### PR DESCRIPTION
## Improvements
* Exposes type-safe Relationship hooks and useRowIds hook

## API change
`type TinyBasedReactHooks<T>` Expects Tinybased build instance as generic instead of Tinybased Table schema, In able infer relationship names for relationship hooks.