### PR TITLE
feat: Setting non-values to undefined/null should trigger cell events via setRow

### DIFF
--- a/packages/tinybased/src/lib/tinybased.ts
+++ b/packages/tinybased/src/lib/tinybased.ts
@@ -120,7 +120,17 @@ export class TinyBased<
     rowId: string,
     row: TBSchema[TTable]
   ) {
-    this.store.setRow(table as string, rowId, row);
+    this.store.transaction(() => {
+      this.store.setRow(table as string, rowId, row);
+      Object.entries(row).forEach(([cellId, value]) => {
+        if (
+          value == undefined &&
+          this.store.hasCell(table as string, rowId, cellId)
+        ) {
+          this.store.delCell(table as string, rowId, cellId);
+        }
+      });
+    });
   }
 
   getRow<TTable extends keyof TBSchema>(table: TTable, rowId: string) {


### PR DESCRIPTION
# Improvements
* Setting value non-null value to undefined/null value via setRow should trigger cell & row event listeners
* Setting value from null to undefined/null value via setRow should not trigger cell or row event listeners