### PR TITLE
feat: add tests for verifying our assumptions about certain TinyBase functionality 

### DIFF
--- a/packages/tinybased/src/lib/tinybased-proofs.spec.ts
+++ b/packages/tinybased/src/lib/tinybased-proofs.spec.ts
@@ -76,8 +76,8 @@ describe('Simple proofs that demonstrate how TinyBase works under the hood', () 
 
       based.setRow('someTable', '1', {
         ...based.getRow('someTable', '1'),
-        trying_null: undefined,
-        trying_undefined: null as unknown as undefined,
+        trying_undefined: undefined,
+        trying_null: null as unknown as undefined,
       });
 
       // IMPORTANT:  When we set cells to undefined they are actually removed automatically from the row

--- a/packages/tinybased/src/lib/tinybased-proofs.spec.ts
+++ b/packages/tinybased/src/lib/tinybased-proofs.spec.ts
@@ -1,0 +1,95 @@
+import { SchemaBuilder, TableBuilder } from '..';
+
+describe('Simple proofs that demonstrate how TinyBase works under the hood', () => {
+  describe('listeners', () => {
+    it('should fire event listeners if a cell is changed to be undefined', async () => {
+      const listener = vi.fn();
+
+      const based = await new SchemaBuilder()
+        .addTable(
+          new TableBuilder('someTable')
+            .add('id', 'string')
+            .addOptional('message', 'string')
+        )
+        .build();
+
+      based.setRow('someTable', '1', {
+        id: '1',
+        message: 'this is my message',
+      });
+
+      based.store.addRowListener(null, null, listener);
+      based.store.addCellListener(null, null, null, listener);
+
+      based.setCell('someTable', '1', 'message', undefined);
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not fire listeners for cell changes if the value is equal', async () => {
+      const listener = vi.fn();
+
+      const based = await new SchemaBuilder()
+        .addTable(
+          new TableBuilder('someTable')
+            .add('id', 'string')
+            .add('num', 'number')
+            .add('str', 'string')
+            .add('bool', 'boolean')
+        )
+        .build();
+
+      based.setRow('someTable', '1', {
+        num: 42,
+        str: 'message',
+        bool: false,
+        id: '1',
+      });
+
+      based.store.addRowListener(null, null, listener);
+      based.store.addCellListener(null, null, null, listener);
+
+      based.setCell('someTable', '1', 'bool', false);
+      based.setCell('someTable', '1', 'str', 'message');
+      based.setCell('someTable', '1', 'num', 42);
+
+      expect(listener).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('undefined handling', () => {
+    it('removes cells that are set to be undefined or null from the row', async () => {
+      const based = await new SchemaBuilder()
+        .addTable(
+          new TableBuilder('someTable')
+            .add('id', 'string')
+            .addOptional('trying_null', 'string')
+            .addOptional('trying_undefined', 'string')
+        )
+        .build();
+
+      based.setRow('someTable', '1', {
+        id: '1',
+        trying_null: 'null',
+        trying_undefined: 'undefined',
+      });
+
+      based.setRow('someTable', '1', {
+        ...based.getRow('someTable', '1'),
+        trying_null: undefined,
+        trying_undefined: null as unknown as undefined,
+      });
+
+      // IMPORTANT:  When we set cells to undefined they are actually removed automatically from the row
+      expect(based.getRow('someTable', '1')).not.toMatchObject({
+        id: '1',
+        trying_null: undefined,
+        trying_undefined: undefined,
+      });
+
+      expect(based.getRow('someTable', '1')).toEqual({
+        id: '1',
+      });
+    });
+  });
+});

--- a/packages/tinybased/src/lib/tinybased.spec.ts
+++ b/packages/tinybased/src/lib/tinybased.spec.ts
@@ -39,6 +39,7 @@ describe('tinybased', () => {
       >
     >();
   });
+
   it('should handle type safe rows and cells', async () => {
     const based = await baseBuilder.build();
     based.setRow('users', '1', exampleUser);
@@ -50,20 +51,6 @@ describe('tinybased', () => {
     based.deleteCell('users', '1', 'age');
     const age2 = based.getCell('users', '1', 'age');
     expect(age2).toBeUndefined();
-  });
-
-  it('handles null/undefined cells', async () => {
-    const based = await baseBuilder.build();
-    based.setRow('users', '1', exampleUser);
-    const onChange = vi.fn();
-
-    based.store.addRowListener(null, null, () => {
-      onChange();
-    });
-
-    based.setCell('users', '1', 'age', null as any);
-
-    expect(onChange).toHaveBeenCalledOnce();
   });
 
   it('getSortedRowIds: should return sorted id by cell', async () => {


### PR DESCRIPTION
## Improvements

- Included some tests that verify our assumptions when it comes to how undefined values interact with TinyBase and listeners
- This proves that setting a cell to undefined works as expected and also triggers listeners. **However**, it is important to note that the cell is actually removed from the row as opposed to having its value be set to undefined