### PR TITLE
feat(full text search): Improve the export type for useSearch

### DIFF
--- a/packages/tinybased/src/lib/search/Searcher-react.spec.tsx
+++ b/packages/tinybased/src/lib/search/Searcher-react.spec.tsx
@@ -14,7 +14,10 @@ import {
 import { waitAMoment } from '../../testing/utils';
 import { SchemaBuilder } from '../SchemaBuilder';
 import { DeepPrettify, InferSchema } from '../types';
-import { connectTinybasedSearcher } from './connectTinybasedSearcher';
+import {
+  connectTinybasedSearcher,
+  UseSearchType,
+} from './connectTinybasedSearcher';
 
 const schemaBuilder = new SchemaBuilder()
   .addTable(usersTable)
@@ -28,14 +31,11 @@ type Schema = DeepPrettify<InferSchema<typeof schemaBuilder>>;
 
 describe('Searcher in react', () => {
   let tb!: Awaited<ReturnType<(typeof schemaBuilder)['build']>>;
-  let builtSearch!: Awaited<
-    ReturnType<typeof connectTinybasedSearcher<Schema, 'users' | 'notes'>>
-  >;
-  let useSearch!: (typeof builtSearch)['useSearch'];
+  let useSearch!: UseSearchType<Schema, 'users' | 'notes'>;
 
   beforeEach(async () => {
     tb = await schemaBuilder.build();
-    builtSearch = await connectTinybasedSearcher(tb, ['users', 'notes']);
+    const builtSearch = await connectTinybasedSearcher(tb, ['users', 'notes']);
     useSearch = builtSearch.useSearch;
   });
 

--- a/packages/tinybased/src/lib/search/connectTinybasedSearcher.tsx
+++ b/packages/tinybased/src/lib/search/connectTinybasedSearcher.tsx
@@ -13,6 +13,20 @@ const SEARCH_LAST_UPDATED_AT = (table: string | symbol | number) =>
   `__internal__tinybased__${String(table)}-last-updated-at`;
 
 /**
+ * Type for defining useSearch generics
+ */
+export type UseSearchType<
+  TBSchema extends TinyBaseSchema,
+  TIndexes extends OnlyStringKeys<TBSchema>
+> = <K extends TIndexes>(
+  index: K,
+  /**
+   * Tables in the Tinybased instance to be indexed and searchable
+   */
+  params: SearchParams<ObjectToCellStringType<TBSchema[K]>>
+) => SearchResult<ObjectToCellStringType<TBSchema[K]>> | undefined;
+
+/**
  * Generates a type-safe Searcher instance and its corresponding `useSearch` hook for a fully
  * connected and reactive Full Text Search of an underlying `tinybased` dataset.
  */
@@ -82,7 +96,7 @@ export const connectTinybasedSearcher = async <
   /**
    * Type-safe, reactive hook to execute `search` on the Searcher instance of a Tinybased instance
    */
-  const useSearch = <K extends TIndexes>(
+  const useSearch: UseSearchType<TBSchema, TIndexes> = <K extends TIndexes>(
     index: K,
     /**
      * Tables in the Tinybased instance to be indexed and searchable


### PR DESCRIPTION
Older TS has issues getting the deep ReturnType of the `connectTinybasedSearcher`. This PR exposes a `UseSearchType` that dramatically simplifies declaring `useSearch` at the consumer level.

```typescript
// BEFORE
  let builtSearch!: Awaited<
    ReturnType<typeof connectTinybasedSearcher<Schema, 'users' | 'notes'>>
  >;
  let useSearch!: (typeof builtSearch)['useSearch'];

// NOW
  let useSearch!: UseSearchType<Schema, 'users' | 'notes'>;
```