### PR TITLE
fix(full text search): ensures that the return type of the connectTinybasedSearcher uses the new UseSearchType

### DIFF
--- a/packages/tinybased/src/lib/search/connectTinybasedSearcher.tsx
+++ b/packages/tinybased/src/lib/search/connectTinybasedSearcher.tsx
@@ -38,10 +38,7 @@ export const connectTinybasedSearcher = async <
   indexes: Array<TIndexes>
 ): Promise<{
   searcher: Searcher<Pick<TBSchema, TIndexes>>;
-  useSearch: <K extends TIndexes>(
-    index: K,
-    params: SearchParams<ObjectToCellStringType<TBSchema[K]>>
-  ) => SearchResult<ObjectToCellStringType<TBSchema[K]>> | undefined;
+  useSearch: UseSearchType<TBSchema, TIndexes>;
 }> => {
   const searchBuilder = new SearcherBuilder();
 


### PR DESCRIPTION
I had missed the explicit return type in the `connectTinybasedSearcher` method to use the new `UseSearchType`. This should ensure that it is accurately used for determining the type of `useSearch` when returned from `connectTinybasedSearcher`.