### PR TITLE
feat(hooks): typesafe useSortedRowIds for tables

### DIFF
--- a/packages/tinybased/src/lib/queries/SimpleQuery.ts
+++ b/packages/tinybased/src/lib/queries/SimpleQuery.ts
@@ -1,5 +1,5 @@
 import { Queries } from 'tinybase/cjs/queries';
-import { DeepPrettify, OnlyStringKeys, QueryOptions, Table } from '../types';
+import { DeepPrettify, OnlyStringKeys, SortOptions, Table } from '../types';
 
 export class SimpleQuery<
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -15,7 +15,7 @@ export class SimpleQuery<
     return this.queries.getResultRowIds(this.queryId);
   }
 
-  public getSortedRowIds(sortBy: TCells, options?: QueryOptions) {
+  public getSortedRowIds(sortBy: TCells, options?: SortOptions) {
     const { descending = false, offset, limit } = options || {};
     return this.queries.getResultSortedRowIds(
       this.queryId,

--- a/packages/tinybased/src/lib/tinybased-react.spec.ts
+++ b/packages/tinybased/src/lib/tinybased-react.spec.ts
@@ -18,7 +18,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 describe('Tinybased React', () => {
   let based: Awaited<ReturnType<typeof makeTinyBasedTestFixture>>;
   let hooks: TinyBasedReactHooks<typeof based>;
-  beforeAll(async () => {
+  beforeEach(async () => {
     based = await makeTinyBasedTestFixture();
     hooks = makeTinybasedHooks(based);
   });
@@ -68,6 +68,26 @@ describe('Tinybased React', () => {
       });
 
       expect(result.current).toEqual([USER_ID_1, USER_ID_2, USER_ID_3]);
+    });
+
+    it('useSortedRowIds', () => {
+      const { result } = renderHook(() =>
+        hooks.useSortedRowIds('users', 'age', { limit: 2 })
+      );
+
+      expect(result.current).toEqual([USER_ID_1, USER_ID_2]);
+
+      const USER_ID_3 = 'user3';
+
+      // Insert a new row that has a younger age than any of the previous rows
+      based.setRow('users', USER_ID_3, {
+        age: 2,
+        isAdmin: false,
+        name: 'Zach',
+        id: USER_ID_3,
+      });
+
+      expect(result.current).toEqual([USER_ID_3, USER_ID_1]);
     });
 
     it('useLocalRowIds', () => {

--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -5,6 +5,7 @@ import {
   useRow as tbUseRow,
   useCell as tbUseCell,
   useRowIds as tbUseRowIds,
+  useSortedRowIds as tbUseSortedRowIds,
   useLocalRowIds as tbUseLocalRowIds,
   useRemoteRowId as tbUseRemoteRowId,
   useResultSortedRowIds,
@@ -17,7 +18,7 @@ import {
   InferRelationShip,
   InferSchema,
   OnlyStringKeys,
-  QueryOptions,
+  SortOptions,
   Table,
 } from './types';
 
@@ -46,7 +47,7 @@ export function useSimpleQueryResultIds(query: SimpleQuery) {
 export function useSimpleQuerySortedResultIds<
   TTable extends Table = {},
   TCells extends OnlyStringKeys<TTable> = never
->(query: SimpleQuery<TTable, TCells>, sortBy: TCells, options?: QueryOptions) {
+>(query: SimpleQuery<TTable, TCells>, sortBy: TCells, options?: SortOptions) {
   const { descending = false, offset, limit } = options || {};
   return useResultSortedRowIds(
     query.queryId,
@@ -73,6 +74,20 @@ export type TinyBasedReactHooks<
   ) => TBSchema[TTable][TCell];
 
   useRowIds: <TTable extends keyof TBSchema>(table: TTable) => string[];
+
+  /**
+   * Returns rows ids for the specified table which are sorted by the specified column. By default
+   * they will be sorted in ascending order, but this and other options for pagination can be provided.
+   * The hook will automatically re-render if the underlying data changes
+   */
+  useSortedRowIds: <
+    TTable extends keyof TBSchema,
+    TCell extends keyof TBSchema[TTable]
+  >(
+    table: TTable,
+    sortBy: TCell,
+    sortOptions?: SortOptions
+  ) => string[];
 
   useRow: <TTable extends keyof TBSchema>(
     table: TTable,
@@ -121,6 +136,25 @@ export function makeTinybasedHooks<
     return tbUseRowIds(table as string, store) as string[];
   };
 
+  const useSortedRowIds = <
+    TTable extends keyof TBSchema,
+    TCell extends keyof TBSchema[TTable]
+  >(
+    table: TTable,
+    sortBy: TCell,
+    sortOptions?: SortOptions
+  ) => {
+    const { descending = false, offset, limit } = sortOptions || {};
+    return tbUseSortedRowIds(
+      table as string,
+      sortBy as string,
+      descending,
+      offset,
+      limit,
+      store
+    );
+  };
+
   const useLocalRowIds = (relationshipName: TRelationships, rowId: string) => {
     return tbUseLocalRowIds(
       relationshipName as string,
@@ -140,6 +174,7 @@ export function makeTinybasedHooks<
   return {
     useCell,
     useRowIds,
+    useSortedRowIds,
     useRow,
     useLocalRowIds,
     useRemoteRowId,

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -63,7 +63,7 @@ export type SchemaPersister<TBSchema extends TinyBaseSchema> = {
 
 export type Aggregations = 'avg' | 'count' | 'sum' | 'max' | 'min';
 
-export type QueryOptions = {
+export type SortOptions = {
   descending?: boolean;
   offset?: number;
   limit?: number;


### PR DESCRIPTION
- Adds another typesafe hook that allows all the rows of a table to sorted/paginated