### PR TITLE
fix: types for useQueryResult for aggregate queries

### DIFF
--- a/packages/tinybased/src/lib/tinybased-react.spec.ts
+++ b/packages/tinybased/src/lib/tinybased-react.spec.ts
@@ -171,6 +171,25 @@ describe('Tinybased React', () => {
 
         expect(result.current).toEqual([USER_ID_2, USER_ID_1, USER_ID_3]);
       });
+
+      it('aggregations', () => {
+        const { result } = renderHook(() =>
+          hooks.useQueryResult(
+            based
+              .query('notes')
+              .select('userId')
+              .group('userId', 'count', 'total')
+          )
+        );
+
+        const agg = result.current['0'];
+
+        expectTypeOf(agg).toMatchTypeOf<{
+          total: number;
+        }>();
+
+        expect(agg.total).toEqual(3);
+      });
     });
   });
 

--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -136,9 +136,17 @@ export type TinyBasedReactHooks<
    */
   useQueryResult: <
     TTable extends OnlyStringKeys<TBSchema>,
+    TSelection extends Record<string, unknown>,
     TResult extends Record<string, unknown>
   >(
-    qb: QueryBuilder<TBSchema, InferRelationships<TB>, TTable, never, TResult>
+    qb: QueryBuilder<
+      TBSchema,
+      InferRelationships<TB>,
+      TTable,
+      never,
+      TSelection,
+      TResult
+    >
   ) => Record<string, TResult>;
 
   useQueryResultIds: (qb: QueryBuilder<TBSchema>) => string[];
@@ -246,7 +254,14 @@ export function makeTinybasedHooks<
     TTable extends OnlyStringKeys<TBSchema>,
     TResult extends Record<string, unknown>
   >(
-    qb: QueryBuilder<TBSchema, InferRelationships<TB>, TTable, never, TResult>
+    qb: QueryBuilder<
+      TBSchema,
+      InferRelationships<TB>,
+      TTable,
+      never,
+      never,
+      TResult
+    >
   ): Record<string, TResult> => {
     const query = useMemo(() => qb.build(), [qb.queryId]);
 


### PR DESCRIPTION
## Improvements

Ensures that when consuming results of aggreation queries in reacts that the types are properly inferred 