### PR TITLE
fix: stacking persistors when re-using schema builder

### DIFF
--- a/packages/tinybased/src/lib/SchemaBuilder.spec.ts
+++ b/packages/tinybased/src/lib/SchemaBuilder.spec.ts
@@ -1,0 +1,35 @@
+import { SchemaBuilder } from './SchemaBuilder';
+import { TableBuilder } from './TableBuilder';
+
+describe('SchemaBuilder', () => {
+  it('should be safe to re-use a schema builder as a template', async () => {
+    const getTableCount = vi.fn();
+    const sb = new SchemaBuilder()
+      .addTable(
+        new TableBuilder('users').add('id', 'string').add('name', 'string')
+      )
+      .addPersister({
+        getTable: () => {
+          getTableCount();
+          return [{ id: '1', name: 'Bob' }];
+        },
+      });
+
+    const tb1 = await sb.build();
+
+    // Another consumer might want to reuse sb as a "template" to instantiate
+    // a different set of data. If it adds its own persistor it could end up
+    // stacking against a different user. Instead, we should ensure that calling build
+    // clears out persistors and hydrators
+
+    const tb2 = await sb
+      .addPersister({
+        getTable: () => [{ id: '2', name: 'Alice' }],
+      })
+      .build();
+
+    const result = tb2.getTable('users');
+
+    expect(getTableCount).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/tinybased/src/lib/SchemaBuilder.ts
+++ b/packages/tinybased/src/lib/SchemaBuilder.ts
@@ -135,11 +135,16 @@ export class SchemaBuilder<
     });
 
     this.persisters.forEach((persister) => {
-      tb.events.onRowAddedOrUpdated.add(persister.onRowAddedOrUpdated);
-      tb.events.onRowRemoved.add(persister.onRowRemoved);
+      if (persister.onRowAddedOrUpdated) {
+        tb.events.onRowAddedOrUpdated.add(persister.onRowAddedOrUpdated);
+      }
+      if (persister.onRowRemoved) {
+        tb.events.onRowRemoved?.add(persister.onRowRemoved);
+      }
     });
 
     tb.init();
+    this.persisters = new Set();
 
     return tb as TinyBased<TBSchema, TRelationshipNames>;
   }

--- a/packages/tinybased/src/lib/tinybased.spec.ts
+++ b/packages/tinybased/src/lib/tinybased.spec.ts
@@ -366,11 +366,10 @@ describe('tinybased', () => {
       },
     });
 
-    basedSchema.addPersister(TestPersister('test_db'));
-
     beforeEach(() => {
       mockStorage = {};
       onRowAddedOrUpdated.mockClear();
+      basedSchema.addPersister(TestPersister('test_db'));
     });
 
     it('calls onInit on build and can access schema', async () => {

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -95,8 +95,8 @@ export type SchemaPersister<TBSchema extends TinyBaseSchema> = {
   getTable: <TTableName extends keyof TBSchema>(
     tableName: TTableName
   ) => Promise<TBSchema[TTableName][]> | TBSchema[TTableName][];
-  onRowAddedOrUpdated: RowChangeHandler<TBSchema>;
-  onRowRemoved: RowChangeHandler<TBSchema>;
+  onRowAddedOrUpdated?: RowChangeHandler<TBSchema>;
+  onRowRemoved?: RowChangeHandler<TBSchema>;
 };
 
 export type Aggregations = 'avg' | 'count' | 'sum' | 'max' | 'min';


### PR DESCRIPTION
## Improvements

Fixes a tricky bug where it is tempting to re-use a schema builder as a template for spawning databases. However, this had the side effect of stacking persistors internal to the SchemaBuilder instance which could cause unwanted hydration of the previous DB's data