### PR TITLE
feat(values api): Adds typesafe values API [CR-2673]

### DIFF
--- a/packages/tinybased/src/fixture/database.ts
+++ b/packages/tinybased/src/fixture/database.ts
@@ -1,4 +1,10 @@
-import { InferTable, SchemaBuilder, TableBuilder } from '../';
+import {
+  InferKeyValueSchema,
+  InferTable,
+  SchemaBuilder,
+  TableBuilder,
+  TinyBaseSchema,
+} from '../';
 
 export const usersTable = new TableBuilder('users')
   .add('id', 'string')
@@ -86,6 +92,7 @@ export async function makeTinyBasedTestFixture() {
   const tinyBasedSample = await new SchemaBuilder()
     .addTable(usersTable)
     .addTable(notesTable)
+    .addValue('online', 'boolean')
     .defineHydrators({
       users: () => Promise.resolve([USER_1, USER_2]),
       notes: () => Promise.resolve([NOTE_1, NOTE_2, NOTE_3]),

--- a/packages/tinybased/src/lib/TableBuilder.ts
+++ b/packages/tinybased/src/lib/TableBuilder.ts
@@ -1,26 +1,10 @@
-import { OnlyStringKeys, Prettify } from './types';
-
-interface CellTypeMap {
-  string: string;
-  number: number;
-  boolean: boolean;
-}
-
-/**
- * Supported Cell Types as string literals
- */
-export type CellStringType = 'string' | 'boolean' | 'number';
-
-/**
- * Maps Cell type to their corresponding CellStringType string literal.
- */
-export type CellTypeToString<T> = T extends string
-  ? 'string'
-  : T extends boolean
-  ? 'boolean'
-  : T extends number
-  ? 'number'
-  : never;
+import {
+  CellStringType,
+  CellTypeMap,
+  CellTypeToString,
+  OnlyStringKeys,
+  Prettify,
+} from './types';
 
 /**
  * Given an Object, convert it to its CellStringType representation.

--- a/packages/tinybased/src/lib/tinybased-react.spec.ts
+++ b/packages/tinybased/src/lib/tinybased-react.spec.ts
@@ -8,26 +8,36 @@ import {
 } from '../fixture/database';
 import { makeTinybasedHooks, TinyBasedReactHooks } from './tinybased-react';
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
 
 describe('Tinybased React', () => {
   let based: Awaited<ReturnType<typeof makeTinyBasedTestFixture>>;
-
   let hooks: TinyBasedReactHooks<typeof based>;
   beforeEach(async () => {
     based = await makeTinyBasedTestFixture();
     hooks = makeTinybasedHooks(based);
   });
   describe('makeHooks', () => {
+    it('useValue', () => {
+      const { result } = renderHook(() => hooks.useValue('online'));
+      expect(result.current).toEqual(undefined);
+
+      based.setValue('online', true);
+
+      expect(result.current).toEqual(true);
+
+      based.setValue('online', false);
+
+      expect(result.current).toEqual(false);
+    });
+
     it('useCell', () => {
       const { result } = renderHook(() =>
         hooks.useCell('users', 'user2', 'name')
       );
       expect(result.current).toEqual('Bob');
 
-      act(() => {
-        based.setCell('users', 'user2', 'name', 'Bob Ross');
-      });
+      based.setCell('users', 'user2', 'name', 'Bob Ross');
 
       expect(result.current).toEqual('Bob Ross');
     });

--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -10,22 +10,30 @@ import {
   useRemoteRowId as tbUseRemoteRowId,
   useResultTable as tbUseResultTable,
   useResultSortedRowIds,
+  useValue as tbUseValue,
 } from 'tinybase/cjs/ui-react';
 import { QueryBuilder } from './queries/QueryBuilder';
 import { TinyBased } from './tinybased';
 import {
+  InferKeyValueSchema,
   InferRelationshipNames,
   InferRelationships,
   InferSchema,
   OnlyStringKeys,
   SortOptions,
+  Table,
   TinyBaseSchema,
 } from './types';
 
 export type TinyBasedReactHooks<
-  TB extends TinyBased<any, any>,
-  TBSchema extends TinyBaseSchema = InferSchema<TB>
+  TB extends TinyBased<any, any, any, any>,
+  TBSchema extends TinyBaseSchema = InferSchema<TB>,
+  TKeyValueSchema extends Table = InferKeyValueSchema<TB>
 > = {
+  useValue: <TKey extends OnlyStringKeys<TKeyValueSchema>>(
+    key: TKey
+  ) => TKeyValueSchema[TKey] | undefined;
+
   useCell: <
     TTable extends keyof TBSchema,
     TCell extends keyof TBSchema[TTable]
@@ -122,7 +130,8 @@ export type TinyBasedReactHooks<
  */
 export function makeTinybasedHooks<
   TB extends TinyBased<any, any>,
-  TBSchema extends TinyBaseSchema = InferSchema<TB>
+  TBSchema extends TinyBaseSchema = InferSchema<TB>,
+  TKeyValueSchema extends Table = InferKeyValueSchema<TB>
 >(tinyBased: TB) {
   const store = tinyBased.store;
 
@@ -269,6 +278,14 @@ export function makeTinybasedHooks<
     );
   };
 
+  const useValue = <TKey extends OnlyStringKeys<TKeyValueSchema>>(
+    key: TKey
+  ): TKeyValueSchema[TKey] | undefined => {
+    return tbUseValue(key, tinyBased.store) as
+      | TKeyValueSchema[TKey]
+      | undefined;
+  };
+
   return {
     useCell,
     useRowIds,
@@ -279,5 +296,6 @@ export function makeTinybasedHooks<
     useQueryResult,
     useQueryResultIds,
     useQuerySortedResultIds,
-  } as TinyBasedReactHooks<TB, TBSchema>;
+    useValue,
+  } as TinyBasedReactHooks<TB, TBSchema, TKeyValueSchema>;
 }

--- a/packages/tinybased/src/lib/tinybased.spec.ts
+++ b/packages/tinybased/src/lib/tinybased.spec.ts
@@ -23,6 +23,26 @@ const exampleNote = {
 const baseBuilder = new SchemaBuilder().addTable(usersTable);
 
 describe('tinybased', () => {
+  describe('Key-Value API', () => {
+    it('Can be defined', async () => {
+      const builder = new SchemaBuilder()
+        .addValue('online', 'boolean')
+        .addValue('userId', 'string');
+
+      const built = await builder.build();
+
+      built.setValue('online', false);
+
+      expect(built.getValue('online')).toEqual(false);
+
+      built.setValue('online', true);
+
+      expect(built.getValue('online')).toEqual(true);
+
+      expect(built.getValue('userId')).toBeUndefined();
+    });
+  });
+
   describe('Basic CRUD', () => {
     it('should provide a typesafe wrapper for setTable', async () => {
       const based = await baseBuilder.build();

--- a/packages/tinybased/src/lib/tinybased.ts
+++ b/packages/tinybased/src/lib/tinybased.ts
@@ -17,6 +17,7 @@ import {
   SchemaHydrator,
   TinyBaseSchema,
   Relationships,
+  Table,
 } from './types';
 import keyBy from 'lodash/keyBy';
 import { TableBuilder } from './TableBuilder';
@@ -29,7 +30,8 @@ const makeTableRowCountMetricName = (tableName: string) =>
 export class TinyBased<
   TBSchema extends TinyBaseSchema = {},
   TRelationshipNames extends string = never,
-  TRelationships extends Relationships<TBSchema> = {}
+  TRelationships extends Relationships<TBSchema> = {},
+  TKeyValueSchema extends Table = {}
 > {
   public readonly store: Store;
   public readonly metrics: Metrics;
@@ -287,5 +289,18 @@ export class TinyBased<
 
   getRemoteRowId(relationshipName: TRelationshipNames, rowId: string) {
     return this.relationships.getRemoteRowId(relationshipName, rowId);
+  }
+
+  getValue<TKey extends OnlyStringKeys<TKeyValueSchema>>(
+    key: TKey
+  ): TKeyValueSchema[TKey] | undefined {
+    return this.store.getValue(key) as TKeyValueSchema[TKey] | undefined;
+  }
+
+  setValue<
+    TKey extends OnlyStringKeys<TKeyValueSchema>,
+    TValue extends TKeyValueSchema[TKey]
+  >(key: TKey, value: TValue) {
+    return this.store.setValue(key, value);
   }
 }

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -9,6 +9,17 @@ export type TinyBaseSchema = Record<string, Table>;
 export type TableNames<TBSchema extends TinyBaseSchema> =
   OnlyStringKeys<TBSchema>;
 
+export type InferKeyValueSchema<T> = T extends SchemaBuilder<
+  infer _S,
+  infer _Rn,
+  infer _R,
+  infer KV
+>
+  ? KV
+  : T extends TinyBased<infer _S, infer _Rn, infer _R, infer KV>
+  ? KV
+  : never;
+
 export type InferSchema<T> = T extends SchemaBuilder<infer S, infer _R>
   ? S
   : T extends TinyBased<infer S, infer _R>
@@ -144,3 +155,25 @@ export type DeepPrettify<T> = T extends object
   : T extends Array<infer U>
   ? Array<DeepPrettify<U>>
   : T;
+
+/**
+ * Supported Cell Types as string literals
+ */
+export type CellStringType = 'string' | 'boolean' | 'number';
+
+/**
+ * Maps Cell type to their corresponding CellStringType string literal.
+ */
+export type CellTypeToString<T> = T extends string
+  ? 'string'
+  : T extends boolean
+  ? 'boolean'
+  : T extends number
+  ? 'number'
+  : never;
+
+export interface CellTypeMap {
+  string: string;
+  number: number;
+  boolean: boolean;
+}


### PR DESCRIPTION
- Adds a new `addValue` method to the `SchemaBuilder` allowing users to define values for TinyBase.
- Adds `useValue`, `setValue` and `getValue` typesafe methods