### PR TITLE
feat: add API for registering typesafe row change listeners [CR-2716]

### DIFF
--- a/packages/tinybased/src/lib/TableBuilder.ts
+++ b/packages/tinybased/src/lib/TableBuilder.ts
@@ -55,6 +55,13 @@ export class TableBuilder<
   }
 
   /**
+   * Returns the names of all of the cells that are attached to this Table
+   */
+  public get cellNames() {
+    return this._cells.map((c) => c.name);
+  }
+
+  /**
    * Returns a schema object
    */
   public get schema(): TableSchema<keyof TCells> {

--- a/packages/tinybased/src/lib/search/connectTinybasedSearcher.tsx
+++ b/packages/tinybased/src/lib/search/connectTinybasedSearcher.tsx
@@ -57,7 +57,7 @@ export const connectTinybasedSearcher = async <
   >;
 
   // upsert handler
-  tinybased.onRowAddedOrUpdated(async (table, rowId, entity) => {
+  tinybased.onAnyRowAddedOrUpdated(async (table, rowId, entity) => {
     if (entity) {
       const existing = await searcher.getByID(table as any, rowId);
       if (existing) {
@@ -74,7 +74,7 @@ export const connectTinybasedSearcher = async <
   }, true);
 
   // removed handler
-  tinybased.onRowRemoved(async (table, rowId, _entity) => {
+  tinybased.onAnyRowRemoved(async (table, rowId, _entity) => {
     await searcher.remove(table as any, rowId);
     tinybased.store.setValue(
       SEARCH_LAST_UPDATED_AT(table),

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import { RowListener } from 'tinybase/store';
 import { SchemaBuilder } from './SchemaBuilder';
 import { CellSchema } from './TableBuilder';
 import { TinyBased } from './tinybased';
@@ -118,6 +119,22 @@ export type RelationshipDefinition = {
   to: string;
   cell: string;
 };
+
+export type CellChanges<T extends Record<string, unknown>> = {
+  [K in keyof T]: {
+    isChanged: boolean;
+    oldValue: T[K] | undefined;
+    newValue: T[K] | undefined;
+  };
+};
+
+export type RowChange<TRow extends Record<string, unknown>> =
+  | {
+      type: 'delete';
+      rowId: string | number;
+    }
+  | { type: 'insert'; row: TRow }
+  | { type: 'update'; row: TRow; changes: CellChanges<TRow> };
 
 export type RowChangeHandler<TBSchema extends TinyBaseSchema> = <
   TName extends keyof TBSchema


### PR DESCRIPTION
## Improvements
- Adds a new typesafe API for registering event listeners that are attached to row changes for a given table
- Does work to determine if this is an insert, update or delete event and give more contextual information back to the event handler to reduce boilerplate