### PR TITLE
fix: check if query exists before attempting to setDefintion again

### DIFF
--- a/packages/tinybased/src/lib/queries/QueryBuilder.ts
+++ b/packages/tinybased/src/lib/queries/QueryBuilder.ts
@@ -270,6 +270,12 @@ export class QueryBuilder<
   }
 
   private internalBuild() {
+    if (this.queries.hasQuery(this.queryId)) {
+      // If the query has already been registered, we don't want to call
+      // setQueryDefinition again since it replaces the original and causes
+      // weird issues in React
+      return;
+    }
     this.queries.setQueryDefinition(
       this.queryId,
       this.startTable,


### PR DESCRIPTION
We were running into some weird issues with `useQuery*` hooks where the query definition would be overwritten during mount/unmount using the same logical query body but it could cause unwanted re-renders