### PR TITLE
feat: improvements to onRowChange API [CR-2765]

### DIFF
--- a/packages/tinybased/src/lib/tinybased.spec.ts
+++ b/packages/tinybased/src/lib/tinybased.spec.ts
@@ -193,6 +193,12 @@ describe('tinybased', () => {
   });
 
   describe('Listeners', () => {
+    let ROW_ID: string;
+
+    beforeAll(() => {
+      ROW_ID = '1';
+    });
+
     it('correctly handles created events', async () => {
       const sb = new SchemaBuilder().addTable(
         new TableBuilder('row').add('id', 'string').add('name', 'string')
@@ -207,8 +213,8 @@ describe('tinybased', () => {
         }
       });
 
-      const row = { name: 'Jesse', id: '1' };
-      tb.setRow('row', '1', row);
+      const row = { name: 'Jesse', id: ROW_ID };
+      tb.setRow('row', ROW_ID, row);
 
       expect(fn).toHaveBeenCalledOnce();
       expect(fn).toHaveBeenCalledWith('insert', row);
@@ -224,26 +230,26 @@ describe('tinybased', () => {
 
       tb.onRowChange('row', (change) => {
         if (change.type === 'update') {
-          fn(change.type, change.row, change.changes);
+          fn(change.type, change.rowId, change.row, change.changes);
         }
       });
 
-      const row = { name: 'Jesse', id: '1' };
-      tb.setRow('row', '1', row);
+      const row = { name: 'Jesse', id: ROW_ID };
+      tb.setRow('row', ROW_ID, row);
 
-      tb.setCell('row', '1', 'name', 'Christyn');
+      tb.setCell('row', ROW_ID, 'name', 'Christyn');
 
       expect(fn).toHaveBeenCalledOnce();
       expect(fn).toHaveBeenCalledWith(
         'update',
-        { id: '1', name: 'Christyn' },
-        expect.objectContaining({
+        ROW_ID,
+        { id: ROW_ID, name: 'Christyn' },
+        {
           name: {
-            isChanged: true,
             oldValue: 'Jesse',
             newValue: 'Christyn',
           },
-        })
+        }
       );
     });
 
@@ -257,19 +263,20 @@ describe('tinybased', () => {
 
       tb.onRowChange('row', (change) => {
         if (change.type === 'delete') {
-          fn(change.type, change.rowId);
+          fn(change.type, change.rowId, change.row);
         }
       });
 
-      const row = { name: 'Jesse', id: '1' };
-      tb.setRow('row', '1', row);
+      const row = { name: 'Jesse', id: ROW_ID };
+      tb.setRow('row', ROW_ID, row);
 
-      tb.deleteRow('row', '1');
+      tb.deleteRow('row', ROW_ID);
 
       expect(fn).toHaveBeenCalledOnce();
-      expect(fn).toHaveBeenCalledWith('delete', '1');
+      expect(fn).toHaveBeenCalledWith('delete', ROW_ID, row);
     });
   });
+
   it('getSortedRowIds: should return sorted id by cell', async () => {
     const based = await baseBuilder.build();
     based.setRow('users', '2', {

--- a/packages/tinybased/src/lib/tinybased.ts
+++ b/packages/tinybased/src/lib/tinybased.ts
@@ -168,7 +168,7 @@ export class TinyBased<
       (_store, _table, rowId, getCellChange) => {
         const operationType: RowChange<TBSchema[TTable]> = (() => {
           if (!this.store.hasRow(table, rowId)) {
-            return { type: 'delete', rowId };
+            return { type: 'delete', rowId, oldRow: {} as any };
           }
 
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -194,10 +194,11 @@ export class TinyBased<
           );
 
           return isInsert
-            ? { type: 'insert', row }
+            ? { type: 'insert', row, rowId }
             : {
                 type: 'update',
                 row,
+                rowId,
                 changes: fromPairs(
                   cellChangePairs as unknown as Array<[string, {}]>
                 ) as unknown as CellChanges<TBSchema[TTable]>,

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -121,8 +121,7 @@ export type RelationshipDefinition = {
 };
 
 export type CellChanges<T extends Record<string, unknown>> = {
-  [K in keyof T]: {
-    isChanged: boolean;
+  [K in keyof T]?: {
     oldValue: T[K] | undefined;
     newValue: T[K] | undefined;
   };
@@ -130,11 +129,10 @@ export type CellChanges<T extends Record<string, unknown>> = {
 export type RowChange<TRow extends Record<string, unknown>> = (
   | {
       type: 'delete';
-      oldRow: TRow;
     }
-  | { type: 'insert'; row: TRow }
-  | { type: 'update'; row: TRow; changes: CellChanges<TRow> }
-) & { rowId: string | number };
+  | { type: 'insert' }
+  | { type: 'update'; changes: CellChanges<TRow> }
+) & { rowId: string | number; row: TRow };
 
 export type RowChangeHandler<TBSchema extends TinyBaseSchema> = <
   TName extends keyof TBSchema

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -132,7 +132,7 @@ export type RowChange<TRow extends Record<string, unknown>> = (
     }
   | { type: 'insert' }
   | { type: 'update'; changes: CellChanges<TRow> }
-) & { rowId: string | number; row: TRow };
+) & { rowId: string; row: TRow };
 
 export type RowChangeHandler<TBSchema extends TinyBaseSchema> = <
   TName extends keyof TBSchema

--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -127,14 +127,14 @@ export type CellChanges<T extends Record<string, unknown>> = {
     newValue: T[K] | undefined;
   };
 };
-
-export type RowChange<TRow extends Record<string, unknown>> =
+export type RowChange<TRow extends Record<string, unknown>> = (
   | {
       type: 'delete';
-      rowId: string | number;
+      oldRow: TRow;
     }
   | { type: 'insert'; row: TRow }
-  | { type: 'update'; row: TRow; changes: CellChanges<TRow> };
+  | { type: 'update'; row: TRow; changes: CellChanges<TRow> }
+) & { rowId: string | number };
 
 export type RowChangeHandler<TBSchema extends TinyBaseSchema> = <
   TName extends keyof TBSchema


### PR DESCRIPTION
- Always include rowId in the payload
- For `update`, generate a changes object that only includes the keys that actually changed
- For `delete`, also pass back the last value of the row before the delete happened