### PR TITLE
chore: add test to prove we can query for undefined cells

### DIFF
--- a/packages/tinybased/src/lib/queries/Query.spec.ts
+++ b/packages/tinybased/src/lib/queries/Query.spec.ts
@@ -208,4 +208,18 @@ describe('QueryBuilder', () => {
 
     expect(result['0']).toEqual({ total: 3, draftCount: 1 });
   });
+
+  it('can query for undefined cells', async () => {
+    const db = await sb.build();
+    db.deleteCell('notes', 'note3', 'isDraft');
+
+    const rowIds = db
+      .query('notes')
+      .where('isDraft', undefined)
+      .select('id')
+      .build()
+      .getResultRowIds();
+
+    expect(rowIds).toEqual(['note3']);
+  });
 });


### PR DESCRIPTION
Demonstrates that our current `where` API works to look for records which have undefined in a particular cell