### PR TITLE
Computed column support [CR-2758]

### DIFF
--- a/packages/tinybased/src/fixture/database.ts
+++ b/packages/tinybased/src/fixture/database.ts
@@ -10,6 +10,9 @@ export const usersTable = new TableBuilder('users')
   .add('id', 'string')
   .add('name', 'string')
   .add('age', 'number')
+  .addComputed('isAdult', 'boolean', ({ age }) => {
+    return age > 18;
+  })
   .add('isAdmin', 'boolean');
 
 export const notesTable = new TableBuilder('notes')
@@ -34,6 +37,7 @@ export const USER_1: UserRow = {
   name: 'Jesse',
   age: 33,
   isAdmin: true,
+  isAdult: true,
 };
 
 export const USER_2: UserRow = {
@@ -48,6 +52,7 @@ export const USER_3: UserRow = {
   id: USER_ID_3,
   age: 16,
   name: 'Jesse',
+  isAdult: false,
 };
 
 export const USER_4: UserRow = {

--- a/packages/tinybased/src/lib/TableBuilder.ts
+++ b/packages/tinybased/src/lib/TableBuilder.ts
@@ -26,6 +26,7 @@ export type CellSchema = {
   name: string;
   type: CellStringType;
   optional?: boolean;
+  compute?: (row: any) => any;
 };
 
 export type InferTable<T> = T extends TableBuilder<infer _TName, infer TCells>
@@ -35,7 +36,11 @@ export type InferTable<T> = T extends TableBuilder<infer _TName, infer TCells>
 export class TableBuilder<
   TName extends string = never,
   // eslint-disable-next-line @typescript-eslint/ban-types
-  TCells extends Record<string, unknown> = {}
+  TCells extends Record<string, unknown> = {},
+  /**
+   * The columns of this table that are computed and therefore should not be set directly by the consumer
+   */
+  TComputedColumns extends string = ''
 > {
   private readonly _cells: CellSchema[] = [];
 
@@ -74,9 +79,13 @@ export class TableBuilder<
   add<TCellName extends string, TCellType extends CellStringType>(
     name: TCellName,
     type: TCellType
-  ): TableBuilder<TName, TCells & Record<TCellName, CellTypeMap[TCellType]>> {
+  ): TableBuilder<
+    TName,
+    TCells & Record<TCellName, CellTypeMap[TCellType]>,
+    TComputedColumns
+  > {
     this._cells.push({ name, type });
-    return this;
+    return this as any;
   }
 
   addOptional<TCellName extends string, TCellType extends CellStringType>(
@@ -84,11 +93,34 @@ export class TableBuilder<
     type: TCellType
   ): TableBuilder<
     TName,
-    TCells & Partial<Record<TCellName, CellTypeMap[TCellType]>>
+    TCells & Partial<Record<TCellName, CellTypeMap[TCellType]>>,
+    TComputedColumns
   > {
     this._cells.push({ name, type, optional: true });
 
-    return this;
+    return this as any;
+  }
+
+  /**
+   * Add a computed column to the table; this column's value is to be derived from other columns
+   */
+  addComputed<TCellName extends string, TCellType extends CellStringType>(
+    name: TCellName,
+    type: TCellType,
+    /**
+     * Function to run to compute this column value based on the current row values
+     */
+    compute: (row: TCells) => CellTypeMap[TCellType]
+  ): TableBuilder<
+    TName,
+    TCells & Record<TCellName, CellTypeMap[TCellType]>,
+    /**
+     * This cell and the previously identified computed cells should be unioned
+     */
+    TCellName | TComputedColumns
+  > {
+    this._cells.push({ name, type, compute });
+    return this as any;
   }
 
   defineKeyDelimiter(delimiter: string) {
@@ -97,6 +129,7 @@ export class TableBuilder<
   }
 
   keyBy<TCellName extends OnlyStringKeys<TCells>>(
+    // TODO: Do not allow computed columns as part of key [CR-2992]
     cells: TCellName | TCellName[]
   ) {
     this._keys = Array.isArray(cells) ? cells : [cells];

--- a/packages/tinybased/src/lib/search/searcher.spec.ts
+++ b/packages/tinybased/src/lib/search/searcher.spec.ts
@@ -7,20 +7,24 @@ const USER_1: UserRow = {
   age: 19,
   name: 'Mikey',
   isAdmin: true,
+  isAdult: true,
 };
 const USER_2: UserRow = {
+  ...USER_1,
   id: 'jadf123',
   age: 35,
   name: 'Jesse',
   isAdmin: false,
 };
 const USER_3: UserRow = {
+  ...USER_1,
   id: 'zzzz9999',
   age: 77,
   name: 'Jessa',
   isAdmin: false,
 };
 const USER_4: UserRow = {
+  ...USER_1,
   id: 'abbbccc1233123',
   age: 21,
   name: 'Deep',

--- a/packages/tinybased/src/lib/search/tinybased-searcher.spec.ts
+++ b/packages/tinybased/src/lib/search/tinybased-searcher.spec.ts
@@ -28,6 +28,7 @@ const SCOOB = {
   id: 'abc123',
   isAdmin: false,
   name: 'Scoob',
+  isAdult: true,
 };
 
 describe('Linking Searcher to a tinybased (hydration, row add/update/remove)', () => {

--- a/packages/tinybased/src/lib/tinybased-react.spec.ts
+++ b/packages/tinybased/src/lib/tinybased-react.spec.ts
@@ -34,15 +34,29 @@ describe('Tinybased React', () => {
       expect(result.current).toBeUndefined();
     });
 
-    it('useCell', () => {
-      const { result } = renderHook(() =>
-        hooks.useCell('users', 'user2', 'name')
-      );
-      expect(result.current).toEqual('Bob');
+    describe('useCell', () => {
+      it('name (static cell)', () => {
+        const { result } = renderHook(() =>
+          hooks.useCell('users', 'user2', 'name')
+        );
+        expect(result.current).toEqual('Bob');
 
-      based.setCell('users', 'user2', 'name', 'Bob Ross');
+        based.setCell('users', 'user2', 'name', 'Bob Ross');
 
-      expect(result.current).toEqual('Bob Ross');
+        expect(result.current).toEqual('Bob Ross');
+      });
+      it('isAdult (computed)', () => {
+        const { result } = renderHook(() =>
+          hooks.useCell('users', 'user2', 'isAdult')
+        );
+
+        based.getRow('users', 'user2');
+        expect(result.current).toEqual(true);
+
+        based.setCell('users', 'user2', 'age', 16);
+
+        expect(result.current).toEqual(false);
+      });
     });
 
     it('useRow', () => {
@@ -52,6 +66,7 @@ describe('Tinybased React', () => {
         name: 'Jesse',
         age: 33,
         isAdmin: true,
+        isAdult: true,
       });
 
       based.setCell('users', 'user1', 'name', 'Jesse Carter');
@@ -61,6 +76,7 @@ describe('Tinybased React', () => {
         name: 'Jesse Carter',
         age: 33,
         isAdmin: true,
+        isAdult: true,
       });
     });
 

--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -26,7 +26,7 @@ import {
 } from './types';
 
 export type TinyBasedReactHooks<
-  TB extends TinyBased<any, any, any, any>,
+  TB extends TinyBased<any, any, any, any, any>,
   TBSchema extends TinyBaseSchema = InferSchema<TB>,
   TKeyValueSchema extends Table = InferKeyValueSchema<TB>
 > = {


### PR DESCRIPTION
# Summary
- Adds computed column support to tables
  - `TableBuilder` has new `addComputed` method to allow a user to define a column that is computed based on the other columns in that row.
  - `TinyBased`
    - hydrators expect the computed column to be populated during hydration. The row listeners will not fire for the initial hydration.
    - all getters types include the computed cells (`getRow`, `getTable`, `getCell`, `useRow`, `useCell`, etc.)
    - all setters types exclude the computed cells (`setTable`, `setRow`, `setCell`), the consumer should never be directly setting computed cells


# Follow-Up Work
- Inter-table computed column support (possibly follow-up ticket) [CR-2993]