### PR TITLE
fix: disable automatic query definition cleanup

### DIFF
--- a/packages/tinybased/src/lib/tinybased-react.ts
+++ b/packages/tinybased/src/lib/tinybased-react.ts
@@ -218,11 +218,13 @@ export function makeTinybasedHooks<
   ): Record<string, TResult> => {
     const query = useMemo(() => qb.build(), [qb.queryId]);
 
-    useEffect(() => {
-      return () => {
-        tinyBased.queries.delQueryDefinition(query.queryId);
-      };
-    }, [tinyBased, query.queryId]);
+    // TODO: It would be nice to clean up the query definitions on unmount but this
+    // appears to be causing problems where the definitions get lost and not properly put back
+    // useEffect(() => {
+    //   return () => {
+    //     tinyBased.queries.delQueryDefinition(query.queryId);
+    //   };
+    // }, [tinyBased, query.queryId]);
 
     return tbUseResultTable(query.queryId, tinyBased.queries) as Record<
       string,
@@ -233,11 +235,13 @@ export function makeTinybasedHooks<
   const useQueryResultIds = (qb: QueryBuilder<TBSchema>) => {
     const query = useMemo(() => qb.build(), [qb.queryId]);
 
-    useEffect(() => {
-      return () => {
-        tinyBased.queries.delQueryDefinition(query.queryId);
-      };
-    }, [tinyBased, query.queryId]);
+    // TODO: It would be nice to clean up the query definitions on unmount but this
+    // appears to be causing problems where the definitions get lost and not properly put back
+    // useEffect(() => {
+    //   return () => {
+    //     tinyBased.queries.delQueryDefinition(query.queryId);
+    //   };
+    // }, [tinyBased, query.queryId]);
 
     return useResultRowIds(query.queryId, tinyBased.queries);
   };
@@ -262,11 +266,13 @@ export function makeTinybasedHooks<
     const { descending = false, offset, limit } = sortOptions || {};
     const query = useMemo(() => qb.build(), [qb.queryId]);
 
-    useEffect(() => {
-      return () => {
-        tinyBased.queries.delQueryDefinition(query.queryId);
-      };
-    }, [tinyBased, query.queryId]);
+    // TODO: It would be nice to clean up the query definitions on unmount but this
+    // appears to be causing problems where the definitions get lost and not properly put back
+    // useEffect(() => {
+    //   return () => {
+    //     tinyBased.queries.delQueryDefinition(query.queryId);
+    //   };
+    // }, [tinyBased, query.queryId]);
 
     return useResultSortedRowIds(
       query.queryId,


### PR DESCRIPTION
We've been seeing strange behavior where queries that are leveraging these hooks get removed and then never put back. As a future optimization it would be nice to bring this functionality back but we need to identity some test suite that reproduces the issue so that we can verify that its been properly addressed