### PR TITLE
fix(computed columns): updates InferTinybasedFromSchemaBuilder to account for computed columns[CR-3159]

### DIFF
--- a/packages/tinybased/src/lib/types.ts
+++ b/packages/tinybased/src/lib/types.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { RowListener } from 'tinybase/store';
 import { SchemaBuilder } from './SchemaBuilder';
 import { CellSchema } from './TableBuilder';
 import { TinyBased } from './tinybased';
@@ -69,9 +68,10 @@ export type InferTinyBasedFromSchemaBuilder<SB> = SB extends SchemaBuilder<
   infer S,
   infer RNs,
   infer R,
-  infer KV
+  infer KV,
+  infer CK
 >
-  ? TinyBased<S, RNs, R, KV>
+  ? TinyBased<S, RNs, R, KV, CK>
   : never;
 
 export type HydrateConfig<


### PR DESCRIPTION
The generic for the computed keys was missing from the `InferTinybasedFromSchemaBuilder`. This PR adds it so that they can be correctly used.